### PR TITLE
Refreshing the ConsumptionState context on login.

### DIFF
--- a/Water Drink Water/src/clients/blazor.wa.tbd/Components/Login.razor.cs
+++ b/Water Drink Water/src/clients/blazor.wa.tbd/Components/Login.razor.cs
@@ -1,13 +1,12 @@
-﻿using blazor.wa.tbd.Infrastructure;
-using blazor.wa.tbd.Services;
+﻿using blazor.wa.tbd.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Authorization;
 
 namespace blazor.wa.tbd.Components;
 
 public partial class Login
 {
     private readonly LoginFormData formData = new();
+    [CascadingParameter] private ConsumptionStateProvider ConsumptionState { get; set; }
     [Inject] public UserService UserService { get; set; }
     [Inject] public NavigationManager NavigationManager { get; set; }
     [Inject] public AuthService AuthService { get; set; }
@@ -28,6 +27,7 @@ public partial class Login
         }
         else
         {
+            await ConsumptionState.RefreshContext();
             NavigationManager.NavigateTo("/log");
         }
     }


### PR DESCRIPTION
I added in the cascading parameter for ConsumptionStateProvider in the login.razor.
I ran the RefreshContext() Method to update the gauge, before you move to a different page.

This ensure it is always updated upon logging in.